### PR TITLE
Run server as non-root user in scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,8 @@ COPY --from=builder /server /server
 ENV NAT_ENV="production"
 EXPOSE 8080
 
+# Run as the conventional nobody UID; no /etc/passwd is needed for a
+# numeric USER directive and scratch images have no useradd utility.
+USER 65534:65534
+
 ENTRYPOINT ["/server"]


### PR DESCRIPTION
## Problem

The `Dockerfile` uses `FROM scratch` (the empty base image) but had no `USER` directive. Docker's default when no `USER` is set is UID 0 — root. Scratch images have no `/etc/passwd` so this is silent; the process runs as root with no indication.

**Why this matters**: Although scratch images have no shell or OS utilities (limiting pivot options), running as root still means:
- Any kernel vulnerability exploited by the process runs as the most privileged UID.
- Kubernetes `PodSecurityPolicy` / `SecurityContext` `runAsNonRoot: true` enforcement will block or fail the pod.
- CIS Benchmark checks flag containers running as root.

## Fix

Use the conventional `nobody` UID (65534). A numeric `USER` directive works in scratch images without needing `/etc/passwd`:

```diff
+# Run as the conventional nobody UID; no /etc/passwd is needed for a
+# numeric USER directive and scratch images have no useradd utility.
+USER 65534:65534
+
 ENTRYPOINT ["/server"]
```

## Testing

```bash
docker build -t inspiration-test .
# Confirm the process does not start as root:
docker run --rm --entrypoint="" inspiration-test /bin/sh  # will fail on scratch — good
# Runtime test via health endpoint:
docker run --rm -p 8080:8080 inspiration-test &
curl http://localhost:8080/healthz
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, server.go, db/  
**Found & fixed**: process running as root (UID 0) in scratch container  
**Already good**: scratch base image, static binary (CGO disabled), stripped binary (`-s -w`), TLS via `ca-certificates`  
**Skipped / future run**: `go.mod` declares `go 1.25.0` and dependencies look current; the BigQuery client uses `GOOGLE_APPLICATION_CREDENTIALS` mounted from a host JSON file — consider migrating to Workload Identity or Secret Manager
