### PR TITLE
Fix CORS bypass: set AllowCredentials=false when AllowedOrigins is wildcard

### DIFF
--- a/server.go
+++ b/server.go
@@ -41,12 +41,6 @@ func main() {
 	r.Use(middleware.RealIP)
 	r.Use(logging.Middleware(log.Desugar(), "icco-cloud"))
 	r.Use(cors.New(cors.Options{
-		// AllowCredentials must be false when AllowedOrigins is ["*"].
-		// Combining a wildcard origin with credentials causes go-chi/cors to
-		// reflect the incoming Origin header, allowing any site to make
-		// credentialed cross-origin requests (CORS bypass). The inspiration
-		// service has no authentication mechanism and no endpoints that set
-		// cookies or session tokens, so credentials are not required.
 		AllowCredentials:   false,
 		OptionsPassthrough: true,
 		AllowedOrigins:     []string{"*"},

--- a/server.go
+++ b/server.go
@@ -41,7 +41,13 @@ func main() {
 	r.Use(middleware.RealIP)
 	r.Use(logging.Middleware(log.Desugar(), "icco-cloud"))
 	r.Use(cors.New(cors.Options{
-		AllowCredentials:   true,
+		// AllowCredentials must be false when AllowedOrigins is ["*"].
+		// Combining a wildcard origin with credentials causes go-chi/cors to
+		// reflect the incoming Origin header, allowing any site to make
+		// credentialed cross-origin requests (CORS bypass). The inspiration
+		// service has no authentication mechanism and no endpoints that set
+		// cookies or session tokens, so credentials are not required.
+		AllowCredentials:   false,
 		OptionsPassthrough: true,
 		AllowedOrigins:     []string{"*"},
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},
@@ -147,10 +153,12 @@ func main() {
 	r.Handle("/favicon.ico", http.FileServer(http.FS(public.Assets)))
 
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      r,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	log.Fatal(srv.ListenAndServe())


### PR DESCRIPTION
## Problem

`server.go` configures CORS with both `AllowCredentials: true` and `AllowedOrigins: []string{"*"}`:

```go
// BEFORE (vulnerable)
r.Use(cors.New(cors.Options{
    AllowCredentials:   true,   // ← dangerous with wildcard origin
    AllowedOrigins:     []string{"*"},
    ...
}).Handler)
```

The CORS specification forbids `Access-Control-Allow-Origin: *` combined with `Access-Control-Allow-Credentials: true` — browsers reject that combination. To work around it, `go-chi/cors` (and most CORS libraries) **reflect the incoming `Origin` header** when credentials are enabled, effectively responding with `Access-Control-Allow-Origin: <attacker-domain>` and `Access-Control-Allow-Credentials: true`.

This means **any website on the internet can make credentialed cross-origin requests** (`fetch(..., {credentials: 'include'})`) to `mood.natwelch.com` and read the responses — a classic CORS bypass (CWE-942).

This exact issue is even documented in a comment in the sibling `reportd` service:

> "Combining a wildcard origin with credentials causes go-chi/cors to reflect the incoming Origin header, allowing any site to make credentialed cross-origin requests (CORS bypass)."

## Impact

The `inspiration` service itself is read-only (no auth, no mutations), so the direct damage is limited to information disclosure of the API responses (image metadata, page counts). However, the pattern is dangerous and easily exploitable, and should be corrected as a matter of security hygiene.

## Fix

Set `AllowCredentials: false`. The service has no authentication mechanism, sets no cookies, and no client code relies on credentialed cross-origin requests.

```go
// AFTER (safe)
r.Use(cors.New(cors.Options{
    AllowCredentials:   false,  // ← correct: wildcard + credentials must not mix
    AllowedOrigins:     []string{"*"},
    ...
}).Handler)
```

A matching explanatory comment has been added so the intent is clear to future readers.

## Secondary fix: missing server timeouts

`ReadHeaderTimeout` and `IdleTimeout` were absent from the `http.Server` config. Both are now set:

```go
srv := &http.Server{
    ReadHeaderTimeout: 5 * time.Second,   // added
    ReadTimeout:       10 * time.Second,
    WriteTimeout:      10 * time.Second,
    IdleTimeout:       60 * time.Second,  // added
}
```

## Testing steps

1. `go build ./...` — should compile cleanly.
2. Make a CORS preflight request to the deployed service and verify the response header is `Access-Control-Allow-Origin: *` (not `Access-Control-Allow-Origin: <your-origin>`) and that `Access-Control-Allow-Credentials` is absent.
3. Confirm existing client behaviour is unaffected (the JS frontend makes unauthenticated GET requests, so removing credentials support has no functional impact).

## Audit note

**Reviewed:** `server.go`, `go.mod`, `Dockerfile`, `db/` package structure, `views/` templates.

**Other findings (not fixed here):**
- `go.mod` uses `go 1.24.0` — current.
- Dependencies look fresh; the open dependabot PR bumps `google.golang.org/api`.
- The service uses `html/template` for views (correct, auto-escaping) — no XSS risk in templates.
- No authentication or mutation endpoints — attack surface is small.

**No existing `audit/` PR on this repo before this one.**
